### PR TITLE
install keepass-2.35+

### DIFF
--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -9,6 +9,7 @@
     - 'ppa:git-core/ppa'
     - 'ppa:shutter/ppa'
     - 'ppa:me-davidsansome/clementine'
+    - 'ppa:jtaylor/keepass' # for KeePass 2.35+
 
 - name: install libraries using APT
   apt: 


### PR DESCRIPTION
* install the edge KeePass is a MUST
  * in order to function with OtpKeyProv Plugin
    * can be used with YubiKey
* http://www.howtogeek.com/93798/install-keepass-password-safe-on-your-ubuntu-or-debian-based-linux-system/

Resolves:
Related:
Signed-off-by: Daniel Andrei Minca <mandrei17@gmail.com>