### PR TITLE
fix folder opening issue on GNOME

### DIFF
--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -33,6 +33,9 @@
     - pidgin
     - purple-skypeweb
 
+- name: fix folder opening issue
+  command: xdg-mime default nautilus.desktop inode/directory
+
 - include: dotfiles.yml
 - include: telegram.yml
 - include: vimproved.yml


### PR DESCRIPTION
When mounting an external storage device a notification appears in top
bar. By clicking on the notification, Nautilus Window manager should
display folder tree from that mounted external device.

Instead, directories are opened by default by Anjuta (which has nothing
to do with folders).

As a result, disable opening folders with Anjuta by default, and replace
it with Nautilus window manager.

More on that issue can be found on ArchLinux forums:
https://bbs.archlinux.org/viewtopic.php?id=166366

Resolves:
Related:
Signed-off-by: Daniel Andrei Minca <mandrei17@gmail.com>