### PR TITLE
enable tap to click for Synaptics

### DIFF
--- a/roles/packages/tasks/packages.yml
+++ b/roles/packages/tasks/packages.yml
@@ -32,6 +32,7 @@
     - the_silver_searcher
     - openconnect
     - networkmanager-openconnect
+    - xf86-input-synaptics
 
 - name: fix folder opening issue
   command: xdg-mime default nautilus.desktop inode/directory

--- a/roles/packages/tasks/synaptics.yml
+++ b/roles/packages/tasks/synaptics.yml
@@ -1,0 +1,10 @@
+---
+- name: deploy the Synaptics configuration file
+  become: true
+  template:
+    src: synaptics.conf.j2
+    dest: /etc/X11/xorg.conf.d/10-synaptics.conf
+    owner: root
+    group: root
+    mode: 0644
+

--- a/roles/packages/templates/synaptics.conf.j2
+++ b/roles/packages/templates/synaptics.conf.j2
@@ -1,0 +1,12 @@
+{{ ansible_managed | comment('plain', prefix='#######\n#', postfix='#\n#######\n') }}
+Section "InputClass"
+    Identifier "touchpad catchall"
+        Driver "synaptics"
+        MatchIsTouchpad "on"
+        MatchDevicePath "/dev/input/event*"
+            Option "TapButton1" "1"
+            Option "TapButton2" "2"
+            Option "TapButton3" "3"
+        Option "VertEdgeScroll" "on"
+        Option "HorizEdgeScroll" "on"
+EndSection


### PR DESCRIPTION
Could not tap to click via Synaptics Touchpad on ArchLinux.

To Enable that configuration, install the driver and deploy the
configuration file, thus enabling the following configuration:

  1 finger tap = left click
  2 finger tap = middle scroll button
  3 finger tap = right click

Resolves: #65
Related:
Signed-off-by: Daniel Andrei Minca <mandrei17@gmail.com>