### PR TITLE
add the weekly mirrorlist update cron job

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -15,6 +15,7 @@
       - "https://github.com/terryma/vim-multiple-cursors.git"
   roles:
     - packages
+    - system-configs
     - arch-docker
     - role: vim-ansible
       tags: vim

--- a/roles/packages/tasks/packages.yml
+++ b/roles/packages/tasks/packages.yml
@@ -38,6 +38,7 @@
     - libreoffice-fresh
     - icedtea-web
     - bind-tools
+    - cronie
 
 - name: fix folder opening issue
   command: xdg-mime default nautilus.desktop inode/directory

--- a/roles/packages/tasks/packages.yml
+++ b/roles/packages/tasks/packages.yml
@@ -38,7 +38,6 @@
     - libreoffice-fresh
     - icedtea-web
     - bind-tools
-    - cronie
 
 - name: fix folder opening issue
   command: xdg-mime default nautilus.desktop inode/directory

--- a/roles/system-configs/tasks/main.yml
+++ b/roles/system-configs/tasks/main.yml
@@ -6,6 +6,14 @@
     state: present
   tags: cron
 
+- name: enable cronie as daemon
+  become: true
+  systemd:
+    name: cronie
+    enabled: true
+    state: started
+  tags: cron
+
 - name: weekly update mirrorlist
   become: true
   cron:

--- a/roles/system-configs/tasks/main.yml
+++ b/roles/system-configs/tasks/main.yml
@@ -4,12 +4,14 @@
   cron:
     name: weekly mirrorlist update
     state: present
-    special_time: weekly
     user: root
+    minute: 0
+    hour: 21
+    cron_file: reflector_mirrorlist-update
     job: >
-      reflector
-        --verbose
-        --latest 5
-        --sort rate
+      reflector \
+        --verbose \
+        --latest 5 \
+        --sort rate \
         --save /etc/pacman.d/mirrorlist
   tags: cron

--- a/roles/system-configs/tasks/main.yml
+++ b/roles/system-configs/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: weekly update mirrorlist
+  become: true
+  cron:
+    name: weekly mirrorlist update
+    state: present
+    special_time: weekly
+    insert_after: true
+    user: root
+    job: >
+      reflector
+        --verbose
+        --latest 5
+        --sort rate
+        --save /etc/pacman.d/mirrorlist
+  tags: cron

--- a/roles/system-configs/tasks/main.yml
+++ b/roles/system-configs/tasks/main.yml
@@ -6,12 +6,13 @@
     state: present
     user: root
     minute: 0
+    weekday: 1
     hour: 21
     cron_file: reflector_mirrorlist-update
     job: >
-      reflector \
-        --verbose \
-        --latest 5 \
-        --sort rate \
+      reflector
+        --verbose
+        --latest 5
+        --sort rate
         --save /etc/pacman.d/mirrorlist
   tags: cron

--- a/roles/system-configs/tasks/main.yml
+++ b/roles/system-configs/tasks/main.yml
@@ -18,8 +18,8 @@
     cron_file: reflector_mirrorlist-update
     job: >
       reflector
-        --verbose
-        --latest 5
-        --sort rate
-        --save /etc/pacman.d/mirrorlist
+      --verbose
+      --latest 5
+      --sort rate
+      --save /etc/pacman.d/mirrorlist
   tags: cron

--- a/roles/system-configs/tasks/main.yml
+++ b/roles/system-configs/tasks/main.yml
@@ -6,7 +6,7 @@
     state: present
   tags: cron
 
-- name: enable cronie as daemon
+- name: start and enable cronie as daemon
   become: true
   systemd:
     name: cronie

--- a/roles/system-configs/tasks/main.yml
+++ b/roles/system-configs/tasks/main.yml
@@ -5,7 +5,6 @@
     name: weekly mirrorlist update
     state: present
     special_time: weekly
-    insert_after: true
     user: root
     job: >
       reflector

--- a/roles/system-configs/tasks/main.yml
+++ b/roles/system-configs/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+- name: install cron dependency
+  become: true
+  pacman:
+    name: cronie
+    state: present
+  tags: cron
+
 - name: weekly update mirrorlist
   become: true
   cron:


### PR DESCRIPTION
Update mirrorlist weekly to avoid any issues with packages.

From time to time, the mirrors are failing, as a result, setup a cron
job to update them weekly and avoid further issues

Resolves: #62
Related:
Signed-off-by: Daniel Andrei Minca <mandrei17@gmail.com>